### PR TITLE
Add class-based Cron Job management to Ammar CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,51 @@ Executing all database migrations:
 php ammar run:db
 ```
 
+#### Managing Cron Jobs
+
+INEX SPA allows you to define and manage scheduled tasks or cron jobs using Ammar CLI. These jobs are PHP classes stored in the `core/cronjobs/` directory. Each job file should be named after the class it contains (e.g., `MyTask.php` for class `MyTask`). Each class must define a public `execute()` method, which contains the logic for the job.
+
+Available commands:
+
+*   **Create a new cron job:**
+    ```bash
+    php ammar make:cronjob -1 YourJobClassName
+    ```
+    This will create a new file `core/cronjobs/YourJobClassName.php` with the following basic structure:
+    ```php
+    <?php
+
+    class YourJobClassName {
+        /**
+         * The main logic for the cron job.
+         */
+        public function execute() {
+            // Your cron job logic here
+            echo "Cron job 'YourJobClassName' executed at " . date('Y-m-d H:i:s') . "\n";
+        }
+    }
+    ```
+
+*   **List all cron jobs:**
+    ```bash
+    php ammar list:cronjobs
+    ```
+    This command displays all available cron jobs.
+
+*   **Run a cron job manually:**
+    ```bash
+    php ammar run:cronjob -1 YourJobClassName
+    ```
+    This is useful for testing your cron job logic.
+
+*   **Delete a cron job:**
+    ```bash
+    php ammar delete:cronjob -1 YourJobClassName
+    ```
+    This will remove the specified cron job file.
+
+**Note:** The actual scheduling of these cron jobs (e.g., running them at specific times) needs to be configured separately using your server's cron facilities (like `crontab` on Linux) to call the `php ammar run:cronjob -1 YourJobClassName` command.
+
 ### INEX SPA Cloud
 
 INEX SPA Cloud is a free hosting service for INEX applications. It supports:

--- a/ammar
+++ b/ammar
@@ -21,6 +21,7 @@ define('CACHE_FOLDER', __DIR__ . '/core/cache');
 define('LANG_FOLDER', __DIR__ . '/lang');
 define('LAYOUT_FOLDER', __DIR__ . '/layouts');
 define('PUBLIC_FOLDER', __DIR__ . '/public');
+define('CRONJOBS_FOLDER', __DIR__ . '/core/cronjobs');
 
 // تأكد من وجود المجلدات المطلوبة
 if (!is_dir(DB_FOLDER)) mkdir(DB_FOLDER);
@@ -29,6 +30,7 @@ if (!is_dir(CACHE_FOLDER)) mkdir(CACHE_FOLDER);
 if (!is_dir(LANG_FOLDER)) mkdir(LANG_FOLDER);
 if (!is_dir(LAYOUT_FOLDER)) mkdir(LAYOUT_FOLDER);
 if (!is_dir(PUBLIC_FOLDER)) mkdir(PUBLIC_FOLDER);
+if (!is_dir(CRONJOBS_FOLDER)) mkdir(CRONJOBS_FOLDER, 0777, true);
 
 // أوامر Ammar CLI
 $commands = [
@@ -37,6 +39,7 @@ $commands = [
     'list:db' => 'List all database files',
     'list:import' => 'List all libraries',
     'list:lang' => 'List all languages',
+    'list:cronjobs' => 'List all cron job files',
     'make:db' => 'Create a new DB File',
     'make:route' => 'Create a new Route File',
     'make:cache' => 'Create a new cache entry',
@@ -45,6 +48,7 @@ $commands = [
     'make:lang' => "Create a new language file",
     'make:layout' => "Create a new layout file",
     'make:auth' => "Create an auth db file",
+    'make:cronjob' => 'Create a new Cron Job file',
     'get:cache' => 'Retrieve a cache entry',
     'get:session' => 'Retrieve a session entry',
     'install:import' => 'Install a new library',
@@ -55,6 +59,7 @@ $commands = [
     'delete:import' => 'Delete an import',
     'delete:session' => 'Delete a session',
     'delete:lang' => "Delete a language file",
+    'delete:cronjob' => 'Delete an existing Cron Job file',
     'ask:gemini' => "Ask Gemini",
     'clear:cache' => 'Clear all cache files',
     'clear:db' => 'Clear all DB files',
@@ -63,6 +68,7 @@ $commands = [
     'clear:start' => 'Clear all startup files',
     'clear:docs' => 'Clear all docs',
     'run:db' => 'Run all .sql files in db folder',
+    'run:cronjob' => 'Manually run a specific Cron Job',
     'serve' => 'Serve the application',
 ];
 
@@ -78,6 +84,72 @@ if (!$command || $command === 'list') {
     echo "Available commands:\n";
     foreach ($commands as $cmd => $desc) {
         echo "  php ammar $cmd - $desc\n";
+    }
+    exit(0);
+}
+
+if ($command === 'run:cronjob') {
+    $className = ucfirst($args['1'] ?? readline("1- What's the cron job class name to run? "));
+    if (!$className) exit("Cron job class name is required!\n");
+
+    $filePath = CRONJOBS_FOLDER . '/' . $className . '.php';
+
+    if (!file_exists($filePath)) {
+        echo "Cron job file not found: {$className}.php\n";
+        exit(1);
+    }
+
+    require_once $filePath;
+
+    if (class_exists($className)) {
+        $jobInstance = new $className();
+        if (method_exists($jobInstance, 'execute') && (new ReflectionMethod($className, 'execute'))->isPublic()) {
+            $jobInstance->execute();
+            echo "Cron job '{$className}' executed successfully.\n";
+        } else {
+            echo "Error: Method 'execute()' not found or not public in class '{$className}'.\n";
+            exit(1);
+        }
+    } else {
+        echo "Error: Class '{$className}' not found in file '{$className}.php'.\n";
+        exit(1);
+    }
+    exit(0);
+}
+
+if ($command === 'delete:cronjob') {
+    $className = ucfirst($args['1'] ?? readline("1- What's the cron job class name to delete? "));
+    if (!$className) exit("Cron job class name is required!\n");
+
+    $filePath = CRONJOBS_FOLDER . '/' . $className . '.php';
+
+    if (!file_exists($filePath)) {
+        echo "Cron job file not found: {$className}.php\n";
+        exit(1);
+    }
+
+    if (unlink($filePath)) {
+        echo "Cron job file deleted: {$className}.php\n";
+    } else {
+        echo "Error deleting cron job file: {$className}.php\n";
+        exit(1);
+    }
+    exit(0);
+}
+
+if ($command === 'list:cronjobs') {
+    if (!is_dir(CRONJOBS_FOLDER)) {
+        echo "No cron jobs directory found.\n";
+        exit(1);
+    }
+    $files = glob(CRONJOBS_FOLDER . '/*.php');
+    if (empty($files)) {
+        echo "No cron jobs found.\n";
+        exit(0);
+    }
+    echo "Available cron jobs:\n";
+    foreach ($files as $file) {
+        echo "  " . basename($file, ".php") . "\n";
     }
     exit(0);
 }
@@ -519,6 +591,20 @@ if ($command == "make:auth") {
     
     file_put_contents($filePath, $sqlTemplate);
     echo "DB file created: $filename\n";
+    exit(0);
+}
+
+if ($command === 'make:cronjob') {
+    $className = ucfirst($args['1'] ?? readline("1- What's the cron job class name? "));
+    if (!$className) exit("Cron job class name is required!\n");
+
+    // CRONJOBS_FOLDER is already defined and directory created globally
+    $filePath = CRONJOBS_FOLDER . '/' . $className . '.php';
+    if (file_exists($filePath)) exit("Cron job file '{$className}.php' already exists!\n");
+
+    $fileContent = "<?php\n\nclass " . $className . " {\n    /**\n     * The main logic for the cron job.\n     */\n    public function execute() {\n        // Your cron job logic here\n        echo \"Cron job '" . $className . "' executed at \" . date('Y-m-d H:i:s') . \"\\n\";\n    }\n}\n";
+    file_put_contents($filePath, $fileContent);
+    echo "Cron job file created: core/cronjobs/{$className}.php\n";
     exit(0);
 }
 


### PR DESCRIPTION
This commit introduces a new feature to manage cron jobs using the Ammar CLI. Cron jobs are now defined as PHP classes within the `core/cronjobs/` directory. Each class must have a public `execute()` method that contains the job's logic.

New Ammar CLI commands:
- `make:cronjob -1 <ClassName>`: Creates a new cron job class file.
- `list:cronjobs`: Lists all available cron job classes.
- `run:cronjob -1 <ClassName>`: Manually executes the specified cron job class.
- `delete:cronjob -1 <ClassName>`: Deletes a cron job class file.

The `README.md` file has been updated to reflect these new commands and the class-based structure for cron jobs. All new commands have been checked to ensure proper functionality.