### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/public/JS/errorOverlay.js
+++ b/public/JS/errorOverlay.js
@@ -90,7 +90,10 @@ document.addEventListener('DOMContentLoaded', function () {
     message.innerHTML = `<strong>Message:</strong> ${error.message.replace(/\n/g, '<br>')}`;
 
     const location = document.createElement('p');
-    location.innerHTML = `<strong>Location:</strong> ${error.file} on line ${error.line}`;
+    const locationLabel = document.createElement('strong');
+    locationLabel.textContent = 'Location:';
+    location.appendChild(locationLabel);
+    location.appendChild(document.createTextNode(` ${error.file} on line ${error.line}`));
 
     content.appendChild(closeButton);
     content.appendChild(title);


### PR DESCRIPTION
Potential fix for [https://github.com/AmmarBasha2011/INEX-SPA/security/code-scanning/2](https://github.com/AmmarBasha2011/INEX-SPA/security/code-scanning/2)

To fix the issue, we need to ensure that any untrusted data interpolated into HTML is properly escaped to prevent XSS. Instead of using `innerHTML` to set the content of the `location` element, we should use `textContent` for the dynamic parts (`error.file` and `error.line`) to ensure they are treated as plain text. For the static HTML structure (`<strong>Location:</strong>`), we can create and append DOM elements programmatically.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
