### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/public/JS/errorOverlay.js
+++ b/public/JS/errorOverlay.js
@@ -87,7 +87,13 @@ document.addEventListener('DOMContentLoaded', function () {
     // title.style.color = 'red';
 
     const message = document.createElement('p');
-    message.innerHTML = `<strong>Message:</strong> ${error.message.replace(/\n/g, '<br>')}`;
+    const messageText = document.createElement('strong');
+    messageText.textContent = 'Message:';
+    message.appendChild(messageText);
+    const messageContent = document.createElement('span');
+    messageContent.textContent = error.message;
+    message.appendChild(messageContent);
+    messageContent.innerHTML = messageContent.innerHTML.replace(/\n/g, '<br>');
 
     const location = document.createElement('p');
     const locationLabel = document.createElement('strong');


### PR DESCRIPTION
Potential fix for [https://github.com/AmmarBasha2011/INEX-SPA/security/code-scanning/1](https://github.com/AmmarBasha2011/INEX-SPA/security/code-scanning/1)

To fix the issue, we need to ensure that the `error.message` content is properly escaped before being inserted into the DOM. Instead of using `innerHTML`, which interprets the string as HTML, we should use `textContent` to safely insert the text into the DOM. If the newlines in the message need to be preserved, we can create a utility function to escape the text and replace newlines with `<br>` elements in a safe manner.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
