### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal vulnerability in getPage.php

### DIFF
--- a/core/functions/PHP/getPage.php
+++ b/core/functions/PHP/getPage.php
@@ -150,6 +150,14 @@ function getPage($RouteName)
 {
     global $Ahmed;
 
+    if (strpos($RouteName, '..') !== false) {
+        if (file_exists(__DIR__ . '/../../../core/errors/403.php')) {
+            loadScripts();
+            include __DIR__ . '/../../../core/errors/403.php';
+        }
+        return;
+    }
+
     $_GET['page'] = $RouteName;
 
     if (empty($_GET['page'])) {

--- a/core/functions/PHP/getPage.php
+++ b/core/functions/PHP/getPage.php
@@ -151,10 +151,11 @@ function getPage($RouteName)
     global $Ahmed;
 
     if (strpos($RouteName, '..') !== false) {
-        if (file_exists(__DIR__ . '/../../../core/errors/403.php')) {
+        if (file_exists(__DIR__.'/../../../core/errors/403.php')) {
             loadScripts();
-            include __DIR__ . '/../../../core/errors/403.php';
+            include __DIR__.'/../../../core/errors/403.php';
         }
+
         return;
     }
 


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix path traversal vulnerability in getPage.php

The `getPage` function in `core/functions/PHP/getPage.php` was vulnerable to path traversal attacks because it did not validate the `$RouteName` parameter (from `$_GET['page']`). This allowed attackers to use '..' sequences to access sensitive files outside the intended directories, such as `.env` or other system files.

This fix adds a check at the beginning of the `getPage` function to detect and block any route containing '..', returning a 403 Forbidden error if detected.

Verification:
- Confirmed the vulnerability using a reproduction script.
- Verified the fix with the same script.
- Ensured no regressions by running the existing test suite.

---
*PR created automatically by Jules for task [1007977609609211082](https://jules.google.com/task/1007977609609211082) started by @AmmarBasha2011*