### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in getPage()

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 
 ## 2025-05-14 - Initial Scan
 Starting security assessment of INEX SPA.
+
+## 2025-05-14 - [Path Traversal in getPage]
+**Vulnerability:** The `getPage()` function in `core/functions/PHP/getPage.php` was vulnerable to path traversal. An attacker could use `..` sequences in the `page` parameter to include and execute arbitrary PHP files or read sensitive files via the `public/` directory check.
+**Learning:** The application was directly concatenating user input with file paths and using `file_exists()`/`include` without sanitizing or validating the input against directory traversal.
+**Prevention:** Always validate and sanitize user-provided file paths. A simple check for `..` can prevent basic traversal, but a more robust approach is to use `realpath()` and verify it stays within the intended directory, or use a whitelist of allowed characters.

--- a/core/functions/PHP/getPage.php
+++ b/core/functions/PHP/getPage.php
@@ -150,6 +150,16 @@ function getPage($RouteName)
 {
     global $Ahmed;
 
+    // Security check: Prevent path traversal by disallowing ".." in the route name.
+    if (strpos($RouteName, '..') !== false) {
+        if (file_exists('core/errors/403.php')) {
+            loadScripts();
+            include 'core/errors/403.php';
+        }
+
+        return;
+    }
+
     $_GET['page'] = $RouteName;
 
     if (empty($_GET['page'])) {


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in getPage()

Identified a critical Path Traversal vulnerability in `core/functions/PHP/getPage.php`. The `getPage()` function used the `$RouteName` (derived from `$_GET['page']`) to check for file existence in the `public/` directory and include it if found. Lack of sanitization allowed an attacker to use `..` to escape the `public/` directory and include sensitive files like `.env` or other system files.

**Vulnerability Detail:**
```php
if (file_exists("public/{$_GET['page']}") && is_file("public/{$_GET['page']}")) {
    include "public/{$_GET['page']}";
    return;
}
```

**Fix:**
Added a check at the beginning of `getPage()` to reject any `$RouteName` containing `..`.

```php
if (strpos($RouteName, '..') !== false) {
    if (file_exists('core/errors/403.php')) {
        loadScripts();
        include 'core/errors/403.php';
    }
    return;
}
```

**Verification:**
1. Created a reproduction script that attempted to include `public/../secret.txt`.
2. Confirmed it was successful before the fix.
3. Confirmed it returns a 403 error page after the fix.
4. Ran the full framework test suite (`tests/test_runner.php`) to ensure no regressions. All tests passed.


---
*PR created automatically by Jules for task [525417565632105267](https://jules.google.com/task/525417565632105267) started by @AmmarBasha2011*